### PR TITLE
Ensure user option is always used for containers to avoid permission denied errors

### DIFF
--- a/aws_panorama_capture_output/output_capture.py
+++ b/aws_panorama_capture_output/output_capture.py
@@ -17,7 +17,7 @@ wdir = str(path.parents[0])+"/terraform/aws/panorama/"
 
 # Capture the External IP address of Panorama from the Terraform output
 eip = json.loads(client.containers.run('hashicorp/terraform:0.12.29', 'output -json -no-color', auto_remove=True,
-                                       volumes_from=socket.gethostname(), working_dir=wdir, environment=variables).decode('utf-8'))
+                                       volumes_from=socket.gethostname(), working_dir=wdir, environment=variables, user=os.getuid()).decode('utf-8'))
 panorama_ip = (eip['primary_eip']['value'])
 panorama_private_ip = (eip['primary_private_ip']['value'])
 secondary_ip = (eip['secondary_eip']['value'])

--- a/aws_panorama_configure/configure_panorama.py
+++ b/aws_panorama_configure/configure_panorama.py
@@ -27,17 +27,17 @@ else:
         fh.write(primary_inventory)
 
 client = DockerClient()
-container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook platformsettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook platformsettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
 # Monitor the log so that the user can see the console output during the run versus waiting until it is complete. The container stops and is removed once the run is complete and this loop will exit at that time.
 for line in container.logs(stream=True):
     print(line.decode('utf-8').strip())
 
 # Run the appropriate Ansible playbook based on if the user selected HA or not
 if os.environ.get('enable_ha') == "true":
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook ha.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook ha.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 else:
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook otp.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook otp.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())

--- a/aws_panorama_deploy/deploy_panorama.py
+++ b/aws_panorama_deploy/deploy_panorama.py
@@ -94,7 +94,7 @@ if tfcommand == 'apply':
     # Init terraform with the modules and providers. The continer will have the some volumes as Panhandler.
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('hashicorp/terraform:0.12.29', 'init -no-color -input=false', auto_remove=True,
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -102,7 +102,7 @@ if tfcommand == 'apply':
         print(line.decode('utf-8').strip())
     # Run terraform apply
     container = client.containers.run('hashicorp/terraform:0.12.29', 'apply -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -111,7 +111,7 @@ if tfcommand == 'apply':
 
     # Capture the IP addresses of Panorama using Terraform output
     eip = json.loads(client.containers.run('hashicorp/terraform:0.12.29', 'output -json -no-color', auto_remove=True,
-                                           volumes_from=socket.gethostname(), working_dir=wdir,
+                                           volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                            environment=variables).decode('utf-8'))
     try:
         panorama_ip = (eip['primary_eip']['value'])
@@ -183,7 +183,7 @@ if tfcommand == 'apply':
 # If the variable is destroy, then destroy the environment and remove the SSH keys.
 elif tfcommand == 'destroy':
     container = client.containers.run('hashicorp/terraform:0.12.29', 'destroy -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/aws_singlevpc_deploy/deploy_singlevpc.py
+++ b/aws_singlevpc_deploy/deploy_singlevpc.py
@@ -60,7 +60,7 @@ with open("inventory.yml", "w") as fh:
 if tfcommand == 'apply':
 
     if os.path.exists('key') is not True:
-        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
         for line in container.logs(stream=True):
@@ -73,7 +73,7 @@ if tfcommand == 'apply':
     # Init terraform with the modules and providers. The continer will have the some volumes as Panhandler.
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('hashicorp/terraform:0.12.29', 'init -no-color -input=false', auto_remove=True,
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -81,14 +81,14 @@ if tfcommand == 'apply':
         print(line.decode('utf-8').strip())
     # Run terraform apply
     container = client.containers.run('hashicorp/terraform:0.12.29', 'apply -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
@@ -104,7 +104,7 @@ elif tfcommand == 'destroy':
     # Add the boostrap key to the variables sent to Terraform so it can create the AWS key pair.
 
     container = client.containers.run('hashicorp/terraform:0.12.29', 'destroy -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -112,7 +112,7 @@ elif tfcommand == 'destroy':
         print(line.decode('utf-8').strip())
     # Remove the SSH keys we used to provision Panorama from the container.
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 

--- a/azure_appgw_deploy/deploy_appgw.py
+++ b/azure_appgw_deploy/deploy_appgw.py
@@ -15,7 +15,8 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Pull in the AWS Provider variables. These are set in the Skillet Environment and are hidden variables so the
 # user doesn't need to adjust them everytime.
 variables = dict(PANOS_PASSWORD=os.environ.get('PASSWORD'), TF_VAR_password=os.environ.get('PASSWORD'),
-                 PANOS_USERNAME='refarchadmin', TF_IN_AUTOMATION='True')
+                 PANOS_USERNAME='refarchadmin', TF_IN_AUTOMATION='True',
+                 HOME='/home/terraform')
 variables.update(TF_VAR_deployment_name=os.environ.get('DEPLOYMENT_NAME'), TF_VAR_azure_region=os.environ.get('AZURE_REGION'), TF_VAR_authcode=os.environ.get('authcode'))
                 # TF_VAR_vpn_peer=os.environ.get('vpn_peer'), TF_VAR_vpn_as=os.environ.get('vpn_as'), TF_VAR_vpn_psk=os.environ.get('vpn_psk'))
 # A variable the defines if we are creating or destroying the environment via terraform. Set in the dropdown
@@ -68,7 +69,8 @@ if tfcommand == 'apply':
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform apply -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -93,7 +95,8 @@ elif tfcommand == 'destroy':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform destroy -auto-approve -no-color -input=false',
     #container = client.containers.run('paloaltonetworks/terraform-azure', "terraform state rm aazurerm_storage_share.this",
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/azure_appgw_deploy/deploy_appgw.py
+++ b/azure_appgw_deploy/deploy_appgw.py
@@ -45,7 +45,7 @@ with open("inventory.yml", "w") as fh:
 if tfcommand == 'apply':
 
     if os.path.exists('key') is not True:
-        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
         for line in container.logs(stream=True):
@@ -59,7 +59,7 @@ if tfcommand == 'apply':
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform init -no-color -input=false', auto_remove=True,
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -68,14 +68,14 @@ if tfcommand == 'apply':
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform apply -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
@@ -93,7 +93,7 @@ elif tfcommand == 'destroy':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform destroy -auto-approve -no-color -input=false',
     #container = client.containers.run('paloaltonetworks/terraform-azure', "terraform state rm aazurerm_storage_share.this",
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -101,7 +101,7 @@ elif tfcommand == 'destroy':
         print(line.decode('utf-8').strip())
     # Remove the SSH keys we used to provision Panorama from the container.
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 

--- a/azure_authenticate/azure_login.py
+++ b/azure_authenticate/azure_login.py
@@ -17,6 +17,7 @@ subscription = os.environ.get('SUBSCRIPTION')
 container = client.containers.run('paloaltonetworks/terraform-azure', 'az login --use-device-code', auto_remove=True,
                                     volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
                                     volumes_from=socket.gethostname(), working_dir=wdir,
+                                  user=os.getuid(),
                                     detach=True)
 # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
 # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -28,6 +29,7 @@ if subscription != '':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'az account set --subscription='+subscription, auto_remove=True,
                                         volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
                                         volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(),
                                         detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/azure_authenticate/azure_login.py
+++ b/azure_authenticate/azure_login.py
@@ -1,10 +1,11 @@
 import os
 import socket
-from docker import DockerClient
 from pathlib import Path
 
+from docker import DockerClient
+
 path = Path(os.getcwd())
-wdir = str(path.parents[0])+'/terraform/azure/panorama/'
+wdir = str(path.parents[0]) + '/terraform/azure/panorama/'
 
 print('Logging in to Azure using device code...')
 
@@ -12,13 +13,20 @@ client = DockerClient()
 
 volume = client.volumes.create(name='terraform-azure')
 
+# ensure we set permissions on this volume to the uid we will be using throughout
+cleanup = client.containers.run('alpine', 'chown -R %s /home/terraform/.azure' % os.getuid(),
+                                volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}}
+                                )
+
 subscription = os.environ.get('SUBSCRIPTION')
 
+# home must be set manually, as containers may not have an entry in etc passwd for all possible uid
+e = dict(HOME="/home/terraform")
 container = client.containers.run('paloaltonetworks/terraform-azure', 'az login --use-device-code', auto_remove=True,
-                                    volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                    volumes_from=socket.gethostname(), working_dir=wdir,
-                                  user=os.getuid(),
-                                    detach=True)
+                                  volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
+                                  volumes_from=socket.gethostname(), working_dir=wdir,
+                                  user=os.getuid(), environment=e,
+                                  detach=True)
 # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
 # The container stops and is removed once the run is complete and this loop will exit at that time.
 for line in container.logs(stream=True):
@@ -26,11 +34,12 @@ for line in container.logs(stream=True):
 
 if subscription != '':
     print('Set the subscription...')
-    container = client.containers.run('paloaltonetworks/terraform-azure', 'az account set --subscription='+subscription, auto_remove=True,
-                                        volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                        volumes_from=socket.gethostname(), working_dir=wdir,
-                                      user=os.getuid(),
-                                        detach=True)
+    container = client.containers.run('paloaltonetworks/terraform-azure',
+                                      'az account set --subscription=' + subscription, auto_remove=True,
+                                      volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
+                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(), environment=e,
+                                      detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):

--- a/azure_panorama_capture_output/output_capture.py
+++ b/azure_panorama_capture_output/output_capture.py
@@ -5,9 +5,9 @@ import json
 from pathlib import Path
 from docker import DockerClient
 
-# Pull in the AWS Provider variables. These are set in Panhandler's skillet environment and are hidden variables so the user
-# doesn't need to adjust them everytime
-variables = dict(TF_IN_AUTOMATION='True')
+# Pull in the AWS Provider variables. These are set in Panhandler's skillet environment and are hidden variables so the
+# user doesn't need to adjust them everytime
+variables = dict(TF_IN_AUTOMATION='True', HOME='/home/terraform')
 
 client = DockerClient()
 

--- a/azure_panorama_capture_output/output_capture.py
+++ b/azure_panorama_capture_output/output_capture.py
@@ -17,7 +17,8 @@ wdir = str(path.parents[0])+"/terraform/azure/panorama/"
 # Capture the External IP address of Panorama from the Terraform output
 eip = json.loads(client.containers.run('paloaltonetworks/terraform-azure', 'terraform output -json -no-color', auto_remove=True,
                                        volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                       volumes_from=socket.gethostname(), working_dir=wdir, environment=variables).decode('utf-8'))
+                                       volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
+                                       environment=variables).decode('utf-8'))
 panorama_ip = (eip['primary_eip']['value'])
 panorama_private_ip = (eip['primary_private_ip']['value'])
 secondary_ip = (eip['secondary_eip']['value'])

--- a/azure_panorama_configure/configure_panorama.py
+++ b/azure_panorama_configure/configure_panorama.py
@@ -27,17 +27,17 @@ else:
         fh.write(primary_inventory)
 
 client = DockerClient()
-container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook platformsettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook platformsettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
 # Monitor the log so that the user can see the console output during the run versus waiting until it is complete. The container stops and is removed once the run is complete and this loop will exit at that time.
 for line in container.logs(stream=True):
     print(line.decode('utf-8').strip())
 
 # Run the appropriate Ansible playbook based on if the user selected HA or not
 if os.environ.get('enable_ha') == "true":
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook ha.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook ha.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 else:
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook otp.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook otp.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())

--- a/azure_panorama_deploy/.meta-cnc.yaml
+++ b/azure_panorama_deploy/.meta-cnc.yaml
@@ -15,8 +15,8 @@ labels:
 variables:
   - name: DEPLOYMENT_NAME
     description: Prefix for deployment
-    default: "Change_Me_to_something_unique"
-    type_hint: hidden
+    default: "unique_123"
+    type_hint: text
     help_text: This value must be unique within the Azure Subscription
   - name: PASSWORD
     description: Admin Password

--- a/azure_panorama_deploy/.meta-cnc.yaml
+++ b/azure_panorama_deploy/.meta-cnc.yaml
@@ -18,6 +18,10 @@ variables:
     default: "unique_123"
     type_hint: text
     help_text: This value must be unique within the Azure Subscription
+    allow_special_characters: False
+    attributes:
+      min: 1
+      max: 8
   - name: PASSWORD
     description: Admin Password
     type_hint: hidden

--- a/azure_panorama_deploy/.meta-cnc.yaml
+++ b/azure_panorama_deploy/.meta-cnc.yaml
@@ -1,6 +1,6 @@
 name: Panorama on Azure
 
-label: 2 - Deploy Panorama
+label: 1 - Deploy Panorama
 
 description: |
   Deploy Panorama with optional HA

--- a/azure_panorama_deploy/.meta-cnc.yaml
+++ b/azure_panorama_deploy/.meta-cnc.yaml
@@ -15,8 +15,9 @@ labels:
 variables:
   - name: DEPLOYMENT_NAME
     description: Prefix for deployment
-    default: ""
+    default: "Change_Me_to_something_unique"
     type_hint: hidden
+    help_text: This value must be unique within the Azure Subscription
   - name: PASSWORD
     description: Admin Password
     type_hint: hidden

--- a/azure_panorama_deploy/deploy_panorama.py
+++ b/azure_panorama_deploy/deploy_panorama.py
@@ -55,7 +55,7 @@ client = DockerClient()
 if tfcommand == 'apply':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'az account list', auto_remove=True,
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -66,7 +66,7 @@ if tfcommand == 'apply':
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform init -no-color -input=false', auto_remove=True,
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -75,7 +75,7 @@ if tfcommand == 'apply':
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform apply -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -85,7 +85,7 @@ if tfcommand == 'apply':
     # Capture the IP addresses of Panorama using Terraform output
     eip = json.loads(client.containers.run('paloaltonetworks/terraform-azure', 'terraform output -json -no-color', auto_remove=True,
                                            volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                           volumes_from=socket.gethostname(), working_dir=wdir,
+                                           volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                            environment=variables).decode('utf-8'))
     try:
         panorama_ip = (eip['primary_eip']['value'])
@@ -158,7 +158,7 @@ if tfcommand == 'apply':
 elif tfcommand == 'destroy':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform destroy -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/azure_panorama_deploy/deploy_panorama.py
+++ b/azure_panorama_deploy/deploy_panorama.py
@@ -25,7 +25,7 @@ def convert(seconds):
 
 # Pull in the AWS Provider variables. These are set in the Skillet Environment and are hidden variables so the
 # user doesn't need to adjust them everytime.
-variables = dict(TF_IN_AUTOMATION='True')
+variables = dict(TF_IN_AUTOMATION='True', HOME='/home/terraform')
 variables.update(TF_VAR_deployment_name=os.environ.get('DEPLOYMENT_NAME'), TF_VAR_vpc_cidr_block=os.environ.get(
                 'vpc_cidr_block'), TF_VAR_enable_ha=os.environ.get('enable_ha'), TF_VAR_password=os.environ.get('PASSWORD'),
                 TF_VAR_azure_region=os.environ.get('AZURE_REGION'))
@@ -75,7 +75,8 @@ if tfcommand == 'apply':
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform apply -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -158,7 +159,8 @@ if tfcommand == 'apply':
 elif tfcommand == 'destroy':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform destroy -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/azure_transitvnet_deploy/deploy_transit.py
+++ b/azure_transitvnet_deploy/deploy_transit.py
@@ -15,7 +15,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Pull in the AWS Provider variables. These are set in the Skillet Environment and are hidden variables so the
 # user doesn't need to adjust them everytime.
 variables = dict(PANOS_PASSWORD=os.environ.get('PASSWORD'), TF_VAR_password=os.environ.get('PASSWORD'),
-                 PANOS_USERNAME='refarchadmin', TF_IN_AUTOMATION='True')
+                 PANOS_USERNAME='refarchadmin', TF_IN_AUTOMATION='True', HOME='/home/terraform')
 variables.update(TF_VAR_deployment_name=os.environ.get('DEPLOYMENT_NAME'), TF_VAR_vpc_cidr_block=os.environ.get(
                 'transit_cidr_block'), TF_VAR_azure_region=os.environ.get('AZURE_REGION'), TF_VAR_authcode=os.environ.get('authcode'))
                 # TF_VAR_vpn_peer=os.environ.get('vpn_peer'), TF_VAR_vpn_as=os.environ.get('vpn_as'), TF_VAR_vpn_psk=os.environ.get('vpn_psk'))
@@ -79,7 +79,8 @@ if tfcommand == 'apply':
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform apply -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -104,7 +105,8 @@ elif tfcommand == 'destroy':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform destroy -auto-approve -no-color -input=false',
     #container = client.containers.run('paloaltonetworks/terraform-azure', "terraform state rm aazurerm_storage_share.this",
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/azure_transitvnet_deploy/deploy_transit.py
+++ b/azure_transitvnet_deploy/deploy_transit.py
@@ -56,7 +56,7 @@ with open("inventory.yml", "w") as fh:
 if tfcommand == 'apply':
 
     if os.path.exists('key') is not True:
-        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
         for line in container.logs(stream=True):
@@ -70,7 +70,7 @@ if tfcommand == 'apply':
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform init -no-color -input=false', auto_remove=True,
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -79,14 +79,14 @@ if tfcommand == 'apply':
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform apply -auto-approve -no-color -input=false',
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
@@ -104,7 +104,7 @@ elif tfcommand == 'destroy':
     container = client.containers.run('paloaltonetworks/terraform-azure', 'terraform destroy -auto-approve -no-color -input=false',
     #container = client.containers.run('paloaltonetworks/terraform-azure', "terraform state rm aazurerm_storage_share.this",
                                       volumes={'terraform-azure': {'bind': '/home/terraform/.azure/', 'mode': 'rw'}},
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -112,7 +112,7 @@ elif tfcommand == 'destroy':
         print(line.decode('utf-8').strip())
     # Remove the SSH keys we used to provision Panorama from the container.
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 

--- a/gcp_application_deploy/deploy_application.py
+++ b/gcp_application_deploy/deploy_application.py
@@ -86,7 +86,7 @@ if tfcommand == 'apply':
     # Init terraform with the modules and providers. The continer will have the some volumes as Panhandler.
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform init -no-color -input=false', auto_remove=True,
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -94,14 +94,14 @@ if tfcommand == 'apply':
         print(line.decode('utf-8').strip())
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform apply -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
@@ -112,7 +112,7 @@ elif tfcommand == 'destroy':
     variables.update(GOOGLE_APPLICATION_CREDENTIALS=shared_wdir+'gcloud')
     variables.update(TF_VAR_ra_key="")
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform destroy -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/gcp_panorama_capture_output/output_capture.py
+++ b/gcp_panorama_capture_output/output_capture.py
@@ -14,7 +14,7 @@ variables = dict(GOOGLE_APPLICATION_CREDENTIALS=wdir+'gcloud', TF_IN_AUTOMATION=
 client = DockerClient()
 # Capture the External IP address of Panorama from the Terraform output
 eip = json.loads(client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform output -json -no-color', auto_remove=True,
-                                       volumes_from=socket.gethostname(), working_dir=wdir, environment=variables).decode('utf-8'))
+                                       volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(), environment=variables).decode('utf-8'))
 panorama_ip = (eip['primary_eip']['value'])
 panorama_private_ip = (eip['primary_private_ip']['value'])
 secondary_ip = (eip['secondary_eip']['value'])

--- a/gcp_panorama_configure/configure_panorama.py
+++ b/gcp_panorama_configure/configure_panorama.py
@@ -27,17 +27,17 @@ else:
         fh.write(primary_inventory)
 
 client = DockerClient()
-container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook platformsettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook platformsettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
 # Monitor the log so that the user can see the console output during the run versus waiting until it is complete. The container stops and is removed once the run is complete and this loop will exit at that time.
 for line in container.logs(stream=True):
     print(line.decode('utf-8').strip())
 
 # Run the appropriate Ansible playbook based on if the user selected HA or not
 if os.environ.get('enable_ha') == "true":
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook ha.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook ha.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 else:
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook otp.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook otp.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())

--- a/gcp_panorama_deploy/deploy_panorama.py
+++ b/gcp_panorama_deploy/deploy_panorama.py
@@ -102,7 +102,7 @@ if tfcommand == 'apply':
     # Init terraform with the modules and providers. The continer will have the some volumes as Panhandler.
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform init -no-color -input=false', auto_remove=True,
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -110,7 +110,7 @@ if tfcommand == 'apply':
         print(line.decode('utf-8').strip())
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform apply -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -119,7 +119,7 @@ if tfcommand == 'apply':
 
     # Capture the IP addresses of Panorama using Terraform output
     eip = json.loads(client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform output -json -no-color', auto_remove=True,
-                                           volumes_from=socket.gethostname(), working_dir=wdir,
+                                           volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                            environment=variables).decode('utf-8'))
     try:
         panorama_ip = (eip['primary_eip']['value'])
@@ -193,7 +193,7 @@ elif tfcommand == 'destroy':
     variables.update(GOOGLE_APPLICATION_CREDENTIALS=wdir+'gcloud')
     variables.update(TF_VAR_ra_key="")
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform destroy -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.

--- a/gcp_sharedvpc_deploy/deploy_sharedvpc.py
+++ b/gcp_sharedvpc_deploy/deploy_sharedvpc.py
@@ -87,7 +87,7 @@ if tfcommand == 'apply':
         fh.write(primary_inventory)
 
     if os.path.exists('key') is not True:
-        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+        container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook panoramasettings.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
         for line in container.logs(stream=True):
@@ -129,7 +129,7 @@ if tfcommand == 'apply':
     # Init terraform with the modules and providers. The continer will have the some volumes as Panhandler.
     # This allows it to access the files Panhandler downloaded from the GIT repo.
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform init -no-color -input=false', auto_remove=True,
-                                      volumes_from=socket.gethostname(), working_dir=wdir,
+                                      volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
@@ -137,14 +137,14 @@ if tfcommand == 'apply':
         print(line.decode('utf-8').strip())
     # Run terraform apply
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform apply -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     #  The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
         print(line.decode('utf-8').strip())
 
-    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), detach=True)
+    container = client.containers.run('paloaltonetworks/pan-ansible', "ansible-playbook commit.yml -e "+ansible_variables+" -i inventory.yml", auto_remove=True, volumes_from=socket.gethostname(), working_dir=os.getcwd(), user=os.getuid(), detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.
     for line in container.logs(stream=True):
@@ -155,7 +155,7 @@ elif tfcommand == 'destroy':
     variables.update(GOOGLE_APPLICATION_CREDENTIALS=wdir+'gcloud')
     variables.update(TF_VAR_ra_key="")
     container = client.containers.run('paloaltonetworks/terraform-gcloud', 'terraform destroy -auto-approve -no-color -input=false',
-                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir,
+                                      auto_remove=True, volumes_from=socket.gethostname(), working_dir=wdir, user=os.getuid(),
                                       environment=variables, detach=True)
     # Monitor the log so that the user can see the console output during the run versus waiting until it is complete.
     # The container stops and is removed once the run is complete and this loop will exit at that time.


### PR DESCRIPTION
## Description

Updated all calls to containers.create to use the `user=os.getuid()` parameter. This ensures that any files written by terraform, azure, ansible, etc can always be written to disk. In some cases, when a user with a UID other than 1000 tries to run this automation, permission denied errors frequently happen. By specifying all containers run with the same UID as the current user, this is avoided entirely.

Also, terraform uses a looks to $HOME using the UID if $HOME is not set, so I added the $HOME env variable to manually point to the /home/terraform folder. This allows the azure provider to correctly located it's auth files in /home/terraform/.azure

## Motivation and Context

Permission denied errors when users had UID other than 1000. This is often the case in Linux setups, and if the end user specifies their own panhandler startup scripts

## How Has This Been Tested?

By importing my fork in Panhandler and deploying a Panorama instance. This was not working previously as the .azure dir would become unreadable to the end user.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
